### PR TITLE
feat: add endpoint for trending tags and update tag search logic

### DIFF
--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -29,6 +29,13 @@ export class PostsController {
     return posts;
   }
 
+  @Get('tags')
+  @ApiOperation({ summary: 'Get trending tags (top 10 most used)' })
+  @ApiResponse({ status: 200, description: 'List of trending tags with usage count', type: [Object] })
+  async getTrendingTags() {
+    return this.postsService.getTrendingTags();
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get a post by id' })
   @ApiParam({ name: 'id', type: String })

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -105,7 +105,7 @@ export class PostsService {
   }
 
   async findByTag(tag: string): Promise<Post[]> {
-    return this.postModel.find({ tags: tag })
+    return this.postModel.find({ tags: { $regex: new RegExp(`^${tag}$`, 'i') } })
       .sort({ createdAt: -1 })
       .populate('createdBy', '-password')
       .populate({
@@ -183,5 +183,22 @@ export class PostsService {
     });
     
     return post;
+  }
+
+  // Remove getAllTags and add trending tags
+  async getTrendingTags(): Promise<{ name: string; count: number }[]> {
+    try {
+      const result = await this.postModel.aggregate([
+        { $unwind: { path: '$tags', preserveNullAndEmptyArrays: false } },
+        { $group: { _id: '$tags', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 },
+        { $project: { _id: 0, name: '$_id', count: 1 } }
+      ]);
+      return result;
+    } catch (error) {
+      console.error('Error in getTrendingTags:', error.message, error.stack);
+      return [];
+    }
   }
 } 


### PR DESCRIPTION
- Implemented a new endpoint in PostsController to retrieve the top 10 trending tags with usage counts.
- Added getTrendingTags method in PostsService to aggregate and return trending tags.
- Updated findByTag method to use a case-insensitive regex for tag searches.