### PR TITLE
fix: update user reaction population to include username instead of l…

### DIFF
--- a/src/posts/comments.service.ts
+++ b/src/posts/comments.service.ts
@@ -69,7 +69,7 @@ export class CommentsService {
     await created.populate('createdBy', '-password');
     await created.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
     const post = await this.postsService.findOne(
       data.postId as unknown as string,
@@ -193,7 +193,7 @@ export class CommentsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
   }
@@ -204,7 +204,7 @@ export class CommentsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
   }
@@ -231,7 +231,7 @@ export class CommentsService {
     await comment.populate('createdBy', '-password');
     await comment.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
 
     // Handle mentions if text was updated
@@ -655,7 +655,7 @@ export class CommentsService {
     await comment.populate('createdBy', '-password');
     await comment.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
 
     return { comment, action };
@@ -667,7 +667,7 @@ export class CommentsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       });
     if (!comment) throw new NotFoundException('Comment not found');
     return comment;

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -35,7 +35,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
 
@@ -48,7 +48,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       });
 
     if (!post) throw new NotFoundException('Post not found');
@@ -74,7 +74,7 @@ export class PostsService {
     await created.populate('createdBy', '-password');
     await created.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
 
     // If post contains code, generate AI suggestions synchronously
@@ -131,7 +131,7 @@ export class PostsService {
     await post.populate('createdBy', '-password');
     await post.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
     return post;
   }
@@ -152,7 +152,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
   }
@@ -164,7 +164,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
   }
@@ -188,7 +188,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
   }
@@ -243,7 +243,7 @@ export class PostsService {
     await post.populate('createdBy', '-password');
     await post.populate({
       path: 'userReactions.userId',
-      select: '_id firstName lastName avatar role',
+      select: '_id firstName lastName username avatar role',
     });
 
     return { post, action };
@@ -313,7 +313,7 @@ export class PostsService {
       .populate('createdBy', '-password')
       .populate({
         path: 'userReactions.userId',
-        select: '_id firstName lastName avatar role',
+        select: '_id firstName lastName username avatar role',
       })
       .exec();
 
@@ -330,7 +330,7 @@ export class PostsService {
           .populate('createdBy', '-password')
           .populate({
             path: 'userReactions.userId',
-            select: '_id firstName lastName avatar role',
+            select: '_id firstName lastName username avatar role',
           })
           .sort({ createdAt: -1 })
           .exec();


### PR DESCRIPTION
…ast name

- Modified the user reaction population in both CommentsService and PostsService to replace 'lastName' with 'username' in the selection of user fields.
- Ensured consistency across all relevant methods for improved user identification in comments and posts.