### PR TITLE
feat: add migration endpoint for backfilling missing reactions in mes…

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -108,6 +108,15 @@ export class ChatController {
     return await this.chatService.removeUserFromRoom(roomId, userId);
   }
 
+  @Post('migrate/reactions')
+  @ApiOperation({ summary: 'Backfill missing reactions fields on old messages' })
+  async migrateReactions(@Req() req: Request & { user: any }) {
+    // Optional: only allow admins
+    // if (req.user?.role !== 'admin') throw new Error('Unauthorized');
+    const result = await this.chatService.migrateMissingReactionsFields();
+    return { migrated: true, ...result };
+  }
+
   @Post('messages/:messageId/reactions')
   @ApiOperation({ summary: 'Add or update a reaction to a message' })
   @ApiBody({

--- a/src/messages/schemas/message.schema.ts
+++ b/src/messages/schemas/message.schema.ts
@@ -83,6 +83,9 @@ export class Message {
   pinned: boolean;
 
   @Prop({ default: false })
+  edited: boolean;
+
+  @Prop({ default: false })
   deleted: boolean;
 
   @Prop({ type: [{ type: Types.ObjectId, ref: 'User' }], default: [] })


### PR DESCRIPTION
…sages

- Introduced a new endpoint to migrate missing reactions fields in old messages, ensuring userReactions is an array and reactions object is initialized with default values.
- Updated the message schema to include an 'edited' field to track message edits.
- Enhanced the ChatService to handle the migration logic, ensuring legacy data is normalized and properly structured.