### PR TITLE
feat: dynamically calculate last activity for chat rooms

### DIFF
--- a/src/chat/schemas/chat-room.schema.ts
+++ b/src/chat/schemas/chat-room.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Types } from 'mongoose';
+import { Document, Types, Schema as MongooseSchema } from 'mongoose';
 
 export type ChatRoomDocument = ChatRoom & Document;
 


### PR DESCRIPTION
- Implemented a new method in ChatService to calculate the last activity (message or reaction) for a chat room, enhancing the chat experience by providing real-time updates.
- Updated ChatGateway to emit last activity information along with new messages and reactions, ensuring all users receive the most recent activity context.
- Adjusted the chat room data structure to include last activity details, improving the overall functionality of the chat system.