### PR TITLE
fix: update Stripe onboarding redirect URL to use environment variable

### DIFF
--- a/src/payments/stripe-connect.controller.ts
+++ b/src/payments/stripe-connect.controller.ts
@@ -33,7 +33,7 @@ export class StripeConnectController {
   ) {
     await this.stripeConnectService.handleOnboardingReturn(state, scope, code);
     // Redirect to a frontend page indicating success or failure
-    res.redirect('http://localhost:3000/settings?stripe_onboard=success');
+    res.redirect(`${process.env.FRONTEND_URL}/settings?stripe_onboard=success`);
   }
 
   @Get('account-status')


### PR DESCRIPTION
- Changed the hardcoded redirect URL in the Stripe onboarding process to utilize the FRONTEND_URL environment variable, improving configuration management and deployment flexibility.